### PR TITLE
Add brick-breaking football game website

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,1 +1,5 @@
 # quiz-badminton
+
+This repository now hosts a small brick-breaking game. Open `index.html` in a browser to play.
+
+Use the left and right arrow keys to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while hidden green bricks give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score.

--- a/index.html
+++ b/index.html
@@ -1,0 +1,15 @@
+<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8" />
+  <title>Brick Breaker Football</title>
+  <link rel="stylesheet" href="style.css" />
+</head>
+<body>
+  <canvas id="gameCanvas" width="480" height="320"></canvas>
+  <div id="score">Score: 0</div>
+  <div id="points-container"></div>
+  <div id="message" class="hidden"></div>
+  <script src="script.js"></script>
+</body>
+</html>

--- a/script.js
+++ b/script.js
@@ -1,0 +1,195 @@
+const canvas = document.getElementById('gameCanvas');
+const ctx = canvas.getContext('2d');
+
+let score = 0;
+const scoreDiv = document.getElementById('score');
+
+const skateboardHeight = 12;
+const skateboardWidth = 90;
+let skateboardX = (canvas.width - skateboardWidth) / 2;
+
+const footballRadius = 10;
+let x = canvas.width / 2;
+let y = canvas.height - 30;
+let dx = 2;
+let dy = -2;
+
+let rightPressed = false;
+let leftPressed = false;
+
+document.addEventListener('keydown', keyDownHandler, false);
+document.addEventListener('keyup', keyUpHandler, false);
+
+const brickRowCount = 5;
+const brickColumnCount = 7;
+const brickWidth = 55;
+const brickHeight = 20;
+const brickPadding = 10;
+const brickOffsetTop = 30;
+const brickOffsetLeft = 30;
+
+let bricks = [];
+for (let c = 0; c < brickColumnCount; c++) {
+  bricks[c] = [];
+  for (let r = 0; r < brickRowCount; r++) {
+    bricks[c][r] = { x: 0, y: 0, status: 1, special: false, hidden: false };
+  }
+}
+
+let specials = 3;
+while (specials > 0) {
+  const c = Math.floor(Math.random() * brickColumnCount);
+  const r = Math.floor(Math.random() * brickRowCount);
+  const b = bricks[c][r];
+  if (!b.special && !b.hidden) {
+    b.special = true;
+    b.hidden = true;
+    specials--;
+  }
+}
+
+let remainingBricks = brickRowCount * brickColumnCount;
+
+function keyDownHandler(e) {
+  if (e.key === 'Right' || e.key === 'ArrowRight') {
+    rightPressed = true;
+  } else if (e.key === 'Left' || e.key === 'ArrowLeft') {
+    leftPressed = true;
+  }
+}
+
+function keyUpHandler(e) {
+  if (e.key === 'Right' || e.key === 'ArrowRight') {
+    rightPressed = false;
+  } else if (e.key === 'Left' || e.key === 'ArrowLeft') {
+    leftPressed = false;
+  }
+}
+
+function drawSkateboard() {
+  ctx.beginPath();
+  ctx.rect(skateboardX, canvas.height - skateboardHeight, skateboardWidth, skateboardHeight);
+  ctx.fillStyle = '#333';
+  ctx.fill();
+  ctx.closePath();
+}
+
+function drawFootball() {
+  ctx.beginPath();
+  ctx.arc(x, y, footballRadius, 0, Math.PI * 2);
+  ctx.fillStyle = '#b5651d';
+  ctx.fill();
+  ctx.closePath();
+}
+
+function drawBricks() {
+  for (let c = 0; c < brickColumnCount; c++) {
+    for (let r = 0; r < brickRowCount; r++) {
+      const b = bricks[c][r];
+      if (b.status === 1 && !b.hidden) {
+        const brickX = (c * (brickWidth + brickPadding)) + brickOffsetLeft;
+        const brickY = (r * (brickHeight + brickPadding)) + brickOffsetTop;
+        b.x = brickX;
+        b.y = brickY;
+        ctx.beginPath();
+        ctx.rect(brickX, brickY, brickWidth, brickHeight);
+        ctx.fillStyle = '#0095DD';
+        ctx.fill();
+        ctx.closePath();
+      } else if (b.status === 2) {
+        ctx.beginPath();
+        ctx.rect(b.x, b.y, brickWidth, brickHeight);
+        ctx.fillStyle = '#27ae60';
+        ctx.fill();
+        ctx.closePath();
+        b.status = 0;
+      }
+    }
+  }
+}
+
+function collisionDetection() {
+  for (let c = 0; c < brickColumnCount; c++) {
+    for (let r = 0; r < brickRowCount; r++) {
+      const b = bricks[c][r];
+      if (b.status === 1 || b.hidden) {
+        const brickX = (c * (brickWidth + brickPadding)) + brickOffsetLeft;
+        const brickY = (r * (brickHeight + brickPadding)) + brickOffsetTop;
+        b.x = brickX;
+        b.y = brickY;
+        if (x > brickX && x < brickX + brickWidth && y > brickY && y < brickY + brickHeight) {
+          dy = -dy;
+          if (b.hidden) {
+            b.hidden = false;
+            b.status = 2;
+            score += 50;
+            showPoints('+50', brickX + brickWidth / 2, brickY);
+          } else {
+            b.status = 0;
+            score += 10;
+            showPoints('+10', brickX + brickWidth / 2, brickY);
+          }
+          remainingBricks--;
+          scoreDiv.textContent = `Score: ${score}`;
+          if (remainingBricks === 0) {
+            endGame();
+          }
+        }
+      }
+    }
+  }
+}
+
+function showPoints(text, x, y) {
+  const container = document.getElementById('points-container');
+  const span = document.createElement('span');
+  span.className = 'points';
+  if (text === '+50') span.classList.add('special');
+  span.textContent = text;
+  const rect = canvas.getBoundingClientRect();
+  span.style.left = rect.left + x + 'px';
+  span.style.top = rect.top + y + 'px';
+  container.appendChild(span);
+  span.addEventListener('animationend', () => span.remove());
+}
+
+function endGame() {
+  const message = document.getElementById('message');
+  message.textContent = `Congratulations! Final Score: ${score}`;
+  message.classList.remove('hidden');
+  cancelAnimationFrame(animationId);
+}
+
+function draw() {
+  ctx.clearRect(0, 0, canvas.width, canvas.height);
+  drawBricks();
+  drawFootball();
+  drawSkateboard();
+  collisionDetection();
+
+  if (x + dx > canvas.width - footballRadius || x + dx < footballRadius) {
+    dx = -dx;
+  }
+  if (y + dy < footballRadius) {
+    dy = -dy;
+  } else if (y + dy > canvas.height - footballRadius) {
+    if (x > skateboardX && x < skateboardX + skateboardWidth) {
+      dy = -dy;
+    } else {
+      dy = -dy;
+    }
+  }
+
+  x += dx;
+  y += dy;
+
+  if (rightPressed && skateboardX < canvas.width - skateboardWidth) {
+    skateboardX += 5;
+  } else if (leftPressed && skateboardX > 0) {
+    skateboardX -= 5;
+  }
+
+  animationId = requestAnimationFrame(draw);
+}
+
+let animationId = requestAnimationFrame(draw);

--- a/style.css
+++ b/style.css
@@ -1,0 +1,58 @@
+body {
+  background: #f0f0f0;
+  text-align: center;
+  font-family: Arial, sans-serif;
+}
+
+#gameCanvas {
+  background: #eee;
+  display: block;
+  margin: 0 auto;
+  border: 1px solid #333;
+}
+
+#score {
+  margin-top: 10px;
+  font-size: 20px;
+}
+
+#points-container {
+  position: relative;
+}
+
+.points {
+  position: absolute;
+  font-size: 14px;
+  animation: rise 1s ease-out forwards;
+  color: #e74c3c;
+}
+
+.points.special {
+  color: #27ae60;
+}
+
+@keyframes rise {
+  from {
+    opacity: 1;
+    transform: translateY(0);
+  }
+  to {
+    opacity: 0;
+    transform: translateY(-20px);
+  }
+}
+
+#message {
+  position: absolute;
+  top: 50%;
+  left: 50%;
+  transform: translate(-50%, -50%);
+  background: rgba(255, 255, 255, 0.95);
+  padding: 20px;
+  border: 2px solid #333;
+  font-size: 24px;
+}
+
+.hidden {
+  display: none;
+}


### PR DESCRIPTION
## Summary
- Implement simple brick-breaking game with skateboard paddle and football.
- Award animated +10 for regular bricks and +50 for hidden green bricks.
- Display congratulations message with final score when all bricks are cleared.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b66cadbf0483209adbd098654ce42c