### PR TITLE
Enable full-screen play and mouse scroll control

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository now hosts a small brick-breaking game. Open `index.html` in a browser to play.
 
-Use the left and right arrow keys to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while hidden green bricks give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score.
+Use the left and right arrow keys or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while hidden green bricks give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.

--- a/index.html
+++ b/index.html
@@ -6,7 +6,7 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <canvas id="gameCanvas" width="480" height="320"></canvas>
+  <canvas id="gameCanvas"></canvas>
   <div id="score">Score: 0</div>
   <div id="points-container"></div>
   <div id="message" class="hidden"></div>

--- a/script.js
+++ b/script.js
@@ -1,6 +1,12 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
 
+function resizeCanvas() {
+  canvas.width = window.innerWidth;
+  canvas.height = window.innerHeight;
+}
+resizeCanvas();
+
 let score = 0;
 const scoreDiv = document.getElementById('score');
 
@@ -19,6 +25,14 @@ let leftPressed = false;
 
 document.addEventListener('keydown', keyDownHandler, false);
 document.addEventListener('keyup', keyUpHandler, false);
+document.addEventListener('wheel', wheelHandler, { passive: false });
+
+window.addEventListener('resize', () => {
+  resizeCanvas();
+  if (skateboardX > canvas.width - skateboardWidth) {
+    skateboardX = canvas.width - skateboardWidth;
+  }
+});
 
 const brickRowCount = 5;
 const brickColumnCount = 7;
@@ -89,6 +103,16 @@ function keyUpHandler(e) {
     rightPressed = false;
   } else if (e.key === 'Left' || e.key === 'ArrowLeft') {
     leftPressed = false;
+  }
+}
+
+function wheelHandler(e) {
+  e.preventDefault();
+  skateboardX += e.deltaY * 0.2;
+  if (skateboardX < 0) {
+    skateboardX = 0;
+  } else if (skateboardX > canvas.width - skateboardWidth) {
+    skateboardX = canvas.width - skateboardWidth;
   }
 }
 
@@ -165,9 +189,8 @@ function showPoints(text, x, y) {
   span.className = 'points';
   if (text === '+50') span.classList.add('special');
   span.textContent = text;
-  const rect = canvas.getBoundingClientRect();
-  span.style.left = rect.left + x + 'px';
-  span.style.top = rect.top + y + 'px';
+  span.style.left = x + 'px';
+  span.style.top = y + 'px';
   container.appendChild(span);
   span.addEventListener('animationend', () => span.remove());
 }

--- a/style.css
+++ b/style.css
@@ -2,22 +2,31 @@ body {
   background: #f0f0f0;
   text-align: center;
   font-family: Arial, sans-serif;
+  margin: 0;
+  overflow: hidden;
 }
 
 #gameCanvas {
   background: #eee;
   display: block;
-  margin: 0 auto;
+  margin: 0;
   border: 1px solid #333;
 }
 
 #score {
-  margin-top: 10px;
+  position: absolute;
+  top: 10px;
+  left: 10px;
   font-size: 20px;
 }
 
 #points-container {
-  position: relative;
+  position: absolute;
+  top: 0;
+  left: 0;
+  width: 100%;
+  height: 100%;
+  pointer-events: none;
 }
 
 .points {


### PR DESCRIPTION
## Summary
- Resize canvas to fill the browser window for a full-screen game
- Allow paddle movement via mouse scroll wheel
- Adjust layout/overlays and documentation for new controls

## Testing
- `node --check script.js`
- `npm test` *(fails: package.json not found)*

------
https://chatgpt.com/codex/tasks/task_e_68b671f0b77c83209bfd08332c731a7f