### PR TITLE
Add rules panel and expand game area

### DIFF
--- a/index.html
+++ b/index.html
@@ -6,10 +6,21 @@
   <link rel="stylesheet" href="style.css" />
 </head>
 <body>
-  <canvas id="gameCanvas"></canvas>
-  <div id="score">Score: 0</div>
-  <div id="points-container"></div>
-  <div id="message" class="hidden"></div>
+  <div id="game-area">
+    <canvas id="gameCanvas"></canvas>
+    <div id="score">Score: 0</div>
+    <div id="points-container"></div>
+    <div id="message" class="hidden"></div>
+  </div>
+  <aside id="rules">
+    <h2>Rules</h2>
+    <ul>
+      <li>Use the arrow keys or mouse wheel to move the skateboard.</li>
+      <li>Break blue bricks for +10 points.</li>
+      <li>Green bricks trigger a quiz for +50 points if answered correctly.</li>
+      <li>Missing the football ends the game.</li>
+    </ul>
+  </aside>
   <script src="script.js"></script>
 </body>
 </html>

--- a/script.js
+++ b/script.js
@@ -1,8 +1,10 @@
 const canvas = document.getElementById('gameCanvas');
 const ctx = canvas.getContext('2d');
+const rulesDiv = document.getElementById('rules');
 
 function resizeCanvas() {
-  canvas.width = window.innerWidth;
+  const availableWidth = window.innerWidth - rulesDiv.offsetWidth;
+  canvas.width = availableWidth;
   canvas.height = window.innerHeight;
 }
 resizeCanvas();

--- a/style.css
+++ b/style.css
@@ -1,9 +1,15 @@
 body {
   background: #f0f0f0;
-  text-align: center;
   font-family: Arial, sans-serif;
   margin: 0;
   overflow: hidden;
+  display: flex;
+  height: 100vh;
+}
+
+#game-area {
+  position: relative;
+  flex: 1;
 }
 
 #gameCanvas {
@@ -11,6 +17,16 @@ body {
   display: block;
   margin: 0;
   border: 1px solid #333;
+}
+
+#rules {
+  width: 250px;
+  padding: 20px;
+  text-align: left;
+  background: #fff;
+  border-left: 1px solid #333;
+  overflow-y: auto;
+  height: 100vh;
 }
 
 #score {


### PR DESCRIPTION
## Summary
- Expand canvas sizing to fill the viewport minus the rules panel
- Introduce right-side rules panel outlining controls and scoring
- Adjust layout styles so game area and rules sit side-by-side

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6741c2820832097412345dcbe6560