### PR TITLE
Label quiz bricks with Q

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,4 +2,4 @@
 
 This repository now hosts a small brick-breaking game. Open `index.html` in a browser to play.
 
-Use the left and right arrow keys or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while hidden green bricks give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.
+Use the left and right arrow keys or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while green bricks marked "Q" give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.

--- a/index.html
+++ b/index.html
@@ -17,7 +17,7 @@
     <ul>
       <li>Use the arrow keys or mouse wheel to move the skateboard.</li>
       <li>Break blue bricks for +10 points.</li>
-      <li>Green bricks trigger a quiz for +50 points if answered correctly.</li>
+      <li>Green bricks labeled "Q" trigger a quiz for +50 points if answered correctly.</li>
       <li>Missing the football ends the game.</li>
     </ul>
   </aside>

--- a/script.js
+++ b/script.js
@@ -145,8 +145,17 @@ function drawBricks() {
         b.y = brickY;
         ctx.beginPath();
         ctx.rect(brickX, brickY, brickWidth, brickHeight);
-        ctx.fillStyle = b.quiz ? '#9b59b6' : '#2980b9';
+        ctx.fillStyle = b.quiz ? '#27ae60' : '#2980b9';
         ctx.fill();
+        if (b.quiz) {
+          ctx.fillStyle = '#ffffff';
+          ctx.font = '16px Arial';
+          ctx.textAlign = 'center';
+          ctx.textBaseline = 'middle';
+          ctx.fillText('Q', brickX + brickWidth / 2, brickY + brickHeight / 2);
+          ctx.textAlign = 'start';
+          ctx.textBaseline = 'alphabetic';
+        }
         ctx.closePath();
       }
     }


### PR DESCRIPTION
## Summary
- Mark quiz-triggering bricks in green with a white "Q" label.
- Mention "Q" labels in the rules and README so players know quiz bricks.

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6789b71148320a55cd7d1975bb168