### PR TITLE
Blur size select after change

### DIFF
--- a/script.js
+++ b/script.js
@@ -23,11 +23,13 @@ const skateboardSizeMap = {
   large: 160
 };
 
-document.getElementById('size-select').addEventListener('change', (e) => {
+const sizeSelect = document.getElementById('size-select');
+sizeSelect.addEventListener('change', (e) => {
   skateboardWidth = skateboardSizeMap[e.target.value];
   if (skateboardX > canvas.width - skateboardWidth) {
     skateboardX = canvas.width - skateboardWidth;
   }
+  sizeSelect.blur();
 });
 
 const footballRadius = 10;


### PR DESCRIPTION
## Summary
- Prevent accidental skateboard size changes by removing focus from the size selector after the player chooses a size.

## Testing
- `npm test`
- `node --check script.js`


------
https://chatgpt.com/codex/tasks/task_e_68b67a5258788320bf3d072019babb3f