### PR TITLE
Distribute bricks and add matrix-style scoreboard

### DIFF
--- a/script.js
+++ b/script.js
@@ -50,15 +50,23 @@ window.addEventListener('resize', () => {
   if (skateboardX > canvas.width - skateboardWidth) {
     skateboardX = canvas.width - skateboardWidth;
   }
+  updateBrickLayout();
 });
 
 const brickRowCount = 5;
 const brickColumnCount = 7;
-const brickWidth = 55;
+let brickWidth = 55;
 const brickHeight = 20;
 const brickPadding = 10;
-const brickOffsetTop = 30;
-const brickOffsetLeft = 30;
+const brickOffsetTop = 60;
+let brickOffsetLeft = 30;
+
+function updateBrickLayout() {
+  brickWidth =
+    (canvas.width - 2 * brickOffsetLeft - (brickColumnCount - 1) * brickPadding) /
+    brickColumnCount;
+}
+updateBrickLayout();
 
 let bricks = [];
 for (let c = 0; c < brickColumnCount; c++) {

--- a/style.css
+++ b/style.css
@@ -41,7 +41,13 @@ body {
   top: 10px;
   left: 10px;
   font-size: 20px;
-  color: #f0f0f0;
+  color: #00ff00;
+  font-family: 'Courier New', Courier, monospace;
+  background: rgba(0, 0, 0, 0.6);
+  padding: 5px 10px;
+  border: 1px solid #00ff00;
+  border-radius: 4px;
+  text-shadow: 0 0 5px #00ff00;
 }
 
 #points-container {


### PR DESCRIPTION
## Summary
- Recalculate brick layout so columns span the canvas and sit below the scoreboard
- Apply Matrix-inspired styling to the scoreboard for a neon green digital feel

## Testing
- `node --check script.js`
- `npm test` *(fails: could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67c4d3adc8320b9ad97763f714408