### PR TITLE
Add gravity control and configurable green bricks

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,5 @@
 This repository now hosts a small brick-breaking game. Open `index.html` in a browser to play.
 
 Use the left and right arrow keys or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while green bricks marked "Q" give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.
+
+The configuration panel lets you choose skateboard size, the number of green quiz bricks, and a gravity value to control ball speed. Bricks are now half-width, doubling the total brick count for added challenge.

--- a/index.html
+++ b/index.html
@@ -29,6 +29,10 @@
       <option value="medium" selected>Medium</option>
       <option value="large">Large</option>
     </select>
+    <label for="green-count">Green Bricks</label>
+    <input id="green-count" type="number" min="0" max="20" value="3" />
+    <label for="gravity-select">Gravity</label>
+    <input id="gravity-select" type="number" min="1" max="10" value="2" />
     <fieldset>
       <legend>Quiz Topics</legend>
       <label><input type="checkbox" class="topic-checkbox" value="ml" checked> Machine Learning</label>

--- a/script.js
+++ b/script.js
@@ -24,6 +24,12 @@ const skateboardSizeMap = {
 };
 
 const sizeSelect = document.getElementById('size-select');
+const greenCountInput = document.getElementById('green-count');
+const gravityInput = document.getElementById('gravity-select');
+
+let gravity = parseFloat(gravityInput.value);
+let quizBrickCount = parseInt(greenCountInput.value, 10);
+
 sizeSelect.addEventListener('change', (e) => {
   skateboardWidth = skateboardSizeMap[e.target.value];
   if (skateboardX > canvas.width - skateboardWidth) {
@@ -32,11 +38,24 @@ sizeSelect.addEventListener('change', (e) => {
   sizeSelect.blur();
 });
 
+greenCountInput.addEventListener('change', (e) => {
+  quizBrickCount = parseInt(e.target.value, 10);
+  initializeBricks();
+  greenCountInput.blur();
+});
+
+gravityInput.addEventListener('change', (e) => {
+  gravity = parseFloat(e.target.value);
+  dx = Math.sign(dx) * gravity;
+  dy = Math.sign(dy) * gravity;
+  gravityInput.blur();
+});
+
 const footballRadius = 10;
 let x = canvas.width / 2;
 let y = canvas.height - 30;
-let dx = 2;
-let dy = -2;
+let dx = gravity;
+let dy = -gravity;
 
 let rightPressed = false;
 let leftPressed = false;
@@ -54,7 +73,7 @@ window.addEventListener('resize', () => {
 });
 
 const brickRowCount = 5;
-const brickColumnCount = 7;
+const brickColumnCount = 14;
 let brickWidth = 55;
 const brickHeight = 20;
 const brickPadding = 10;
@@ -69,26 +88,30 @@ function updateBrickLayout() {
 updateBrickLayout();
 
 let bricks = [];
-for (let c = 0; c < brickColumnCount; c++) {
-  bricks[c] = [];
-  for (let r = 0; r < brickRowCount; r++) {
-    bricks[c][r] = { x: 0, y: 0, status: 1, quiz: false };
+let remainingBricks = 0;
+
+function initializeBricks() {
+  bricks = [];
+  for (let c = 0; c < brickColumnCount; c++) {
+    bricks[c] = [];
+    for (let r = 0; r < brickRowCount; r++) {
+      bricks[c][r] = { x: 0, y: 0, status: 1, quiz: false };
+    }
   }
+  let quizBricks = Math.min(quizBrickCount, brickRowCount * brickColumnCount);
+  while (quizBricks > 0) {
+    const c = Math.floor(Math.random() * brickColumnCount);
+    const r = Math.floor(Math.random() * brickRowCount);
+    const b = bricks[c][r];
+    if (!b.quiz) {
+      b.quiz = true;
+      quizBricks--;
+    }
+  }
+  remainingBricks = brickRowCount * brickColumnCount;
 }
 
-// designate random green bricks that trigger quiz questions
-let quizBricks = 3;
-while (quizBricks > 0) {
-  const c = Math.floor(Math.random() * brickColumnCount);
-  const r = Math.floor(Math.random() * brickRowCount);
-  const b = bricks[c][r];
-  if (!b.quiz) {
-    b.quiz = true;
-    quizBricks--;
-  }
-}
-
-let remainingBricks = brickRowCount * brickColumnCount;
+initializeBricks();
 
 const questionMap = {
   ml: [


### PR DESCRIPTION
## Summary
- allow selecting number of green quiz bricks
- add gravity option to adjust ball speed
- double default brick columns for more challenge

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b67df4754483208a38da2e471e3d4e