### PR TITLE
feat: add mouse control

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,6 +2,6 @@
 
 This repository now hosts a small brick-breaking game. Open `index.html` in a browser to play.
 
-Use the left and right arrow keys or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while green bricks marked "Q" give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.
+Use the left and right arrow keys, your mouse, or the mouse scroll wheel to move the skateboard and bounce the football into the bricks. Regular bricks award +10 points, while green bricks marked "Q" give +50 points when hit. Once all bricks are destroyed, a congratulations message displays your final score. The game automatically expands to fill the entire browser window for a full-screen experience.
 
 The configuration panel lets you choose skateboard size, the number of green quiz bricks, and a gravity value to control ball speed. Bricks are now half-width, doubling the total brick count for added challenge.

--- a/index.html
+++ b/index.html
@@ -15,7 +15,7 @@
   <aside id="rules">
     <h2>Rules</h2>
     <ul>
-      <li>Use the arrow keys or mouse wheel to move the skateboard.</li>
+      <li>Use the arrow keys, mouse movement, or mouse wheel to move the skateboard.</li>
       <li>Break blue bricks for +10 points.</li>
       <li>Green bricks labeled "Q" trigger a quiz for +50 points if answered correctly.</li>
       <li>Missing the football ends the game.</li>

--- a/script.js
+++ b/script.js
@@ -63,6 +63,7 @@ let leftPressed = false;
 document.addEventListener('keydown', keyDownHandler, false);
 document.addEventListener('keyup', keyUpHandler, false);
 document.addEventListener('wheel', wheelHandler, { passive: false });
+document.addEventListener('mousemove', mouseMoveHandler, false);
 
 window.addEventListener('resize', () => {
   resizeCanvas();
@@ -213,6 +214,17 @@ function keyUpHandler(e) {
 function wheelHandler(e) {
   e.preventDefault();
   skateboardX += e.deltaY * 0.2;
+  if (skateboardX < 0) {
+    skateboardX = 0;
+  } else if (skateboardX > canvas.width - skateboardWidth) {
+    skateboardX = canvas.width - skateboardWidth;
+  }
+}
+
+function mouseMoveHandler(e) {
+  const rect = canvas.getBoundingClientRect();
+  const relativeX = e.clientX - rect.left;
+  skateboardX = relativeX - skateboardWidth / 2;
   if (skateboardX < 0) {
     skateboardX = 0;
   } else if (skateboardX > canvas.width - skateboardWidth) {


### PR DESCRIPTION
## Summary
- allow the skateboard to follow mouse movement in addition to existing controls
- document mouse control in the in-game rules and README

## Testing
- `node --check script.js`
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b680e8899083208b4bc22ca531f662