### PR TITLE
Load quiz content from JSON

### DIFF
--- a/index.html
+++ b/index.html
@@ -33,12 +33,8 @@
     <input id="green-count" type="number" min="0" max="20" value="3" />
     <label for="gravity-select">Gravity</label>
     <input id="gravity-select" type="number" min="1" max="10" value="2" />
-    <fieldset>
+    <fieldset id="topics">
       <legend>Quiz Topics</legend>
-      <label><input type="checkbox" class="topic-checkbox" value="ml" checked> Machine Learning</label>
-      <label><input type="checkbox" class="topic-checkbox" value="agents" checked> AI Agents</label>
-      <label><input type="checkbox" class="topic-checkbox" value="lm" checked> Language Modelling</label>
-      <label><input type="checkbox" class="topic-checkbox" value="rag" checked> Retrieval Augmented Generation</label>
     </fieldset>
   </aside>
   <script src="script.js"></script>

--- a/script.js
+++ b/script.js
@@ -114,80 +114,34 @@ function initializeBricks() {
 
 initializeBricks();
 
-const questionMap = {
-  ml: [
-    {
-      question: 'Which algorithm can be used for both classification and regression?',
-      options: ['K-means', 'Linear Regression', 'Decision Tree', 'Apriori'],
-      answer: 3
-    },
-    {
-      question: 'What does an activation function introduce in a neural network?',
-      options: ['Bias', 'Non-linearity', 'Regularization', 'Momentum'],
-      answer: 2
-    },
-    {
-      question: 'Which metric is suitable for evaluating imbalanced classification problems?',
-      options: ['Accuracy', 'Mean Squared Error', 'Precision-Recall', 'R-squared'],
-      answer: 3
-    }
-  ],
-  agents: [
-    {
-      question: 'What component of an AI agent selects actions to achieve goals?',
-      options: ['Planner', 'Sensor', 'Actuator', 'Environment'],
-      answer: 1
-    },
-    {
-      question: 'Which architecture combines perception, decision, and action layers?',
-      options: ['BDI', 'Reactive', 'Hybrid', 'Rule-based'],
-      answer: 3
-    },
-    {
-      question: "An agent's ability to consider consequences of actions is called?",
-      options: ['Learning', 'Deliberation', 'Perception', 'Execution'],
-      answer: 2
-    }
-  ],
-  lm: [
-    {
-      question: 'What does a language model assign to sequences of words?',
-      options: ['Syntax trees', 'Part-of-speech tags', 'Probability', 'Embeddings'],
-      answer: 3
-    },
-    {
-      question: 'Which technique predicts the next word given previous words?',
-      options: ['Clustering', 'Next-token prediction', 'Machine translation', 'Summarization'],
-      answer: 2
-    },
-    {
-      question: 'What is a common pretraining objective for transformers?',
-      options: ['Autoencoding', 'Reinforcement learning', 'Rule mining', 'Decision trees'],
-      answer: 1
-    }
-  ],
-  rag: [
-    {
-      question: 'What does RAG combine?',
-      options: ['Generation with perception', 'Retrieval with generation', 'Planning with control', 'Classification with regression'],
-      answer: 2
-    },
-    {
-      question: 'In RAG, retrieved documents are used to:',
-      options: ['Train the model from scratch', 'Improve prompts', 'Provide context for generation', 'Evaluate system performance'],
-      answer: 3
-    },
-    {
-      question: 'Which component retrieves relevant documents in RAG?',
-      options: ['Generator', 'Retriever', 'Decoder', 'Optimizer'],
-      answer: 2
-    }
-  ]
-};
+let questionMap = {};
+
+async function loadQuestions() {
+  const res = await fetch('questions.json');
+  questionMap = await res.json();
+  populateTopics();
+}
+
+function populateTopics() {
+  const fieldset = document.getElementById('topics');
+  if (!fieldset) return;
+  Object.keys(questionMap).forEach(topic => {
+    const label = document.createElement('label');
+    const checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    checkbox.className = 'topic-checkbox';
+    checkbox.value = topic;
+    checkbox.checked = true;
+    label.appendChild(checkbox);
+    label.append(` ${topic}`);
+    fieldset.appendChild(label);
+  });
+}
 
 function askQuestion() {
   const selected = Array.from(document.querySelectorAll('.topic-checkbox:checked')).map(cb => cb.value);
-  const activeTopics = selected.length ? selected : ['ml'];
+  const fallback = Object.keys(questionMap)[0];
+  const activeTopics = selected.length ? selected : [fallback];
   const pool = activeTopics.flatMap(topic => questionMap[topic]);
   const q = pool[Math.floor(Math.random() * pool.length)];
   const choices = q.options.map((opt, i) => `${i + 1}. ${opt}`).join('\n');
@@ -360,5 +314,8 @@ function draw() {
   animationId = requestAnimationFrame(draw);
 }
 
-let animationId = requestAnimationFrame(draw);
+let animationId;
+loadQuestions().then(() => {
+  animationId = requestAnimationFrame(draw);
+});
 


### PR DESCRIPTION
## Summary
- Generate quiz topic checkboxes dynamically
- Fetch question sets from questions.json and use them during gameplay

## Testing
- `npm test` *(fails: missing package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68b6853272188320adaef9abadc0002e