### PR TITLE
Add NYC city option with building obstacles

### DIFF
--- a/index.html
+++ b/index.html
@@ -35,6 +35,11 @@
     <input id="green-count" type="number" min="0" max="20" value="3" />
     <label for="gravity-select">Gravity</label>
     <input id="gravity-select" type="number" min="1" max="10" value="2" />
+    <label for="city-select">Game City</label>
+    <select id="city-select">
+      <option value="flat" selected>Flat Land</option>
+      <option value="nyc">NYC</option>
+    </select>
     <fieldset id="topics">
       <legend>Quiz Topics</legend>
     </fieldset>


### PR DESCRIPTION
## Summary
- Add Game City configuration dropdown with Flat Land and NYC options
- Generate NYC buildings with varied heights and colors and place skateboard between central buildings
- Render buildings and handle ball collisions against them

## Testing
- `npm test` *(fails: Could not read package.json)*

------
https://chatgpt.com/codex/tasks/task_e_68c49b4c61d08320b7030719848577f4